### PR TITLE
상품 수량 조절시 이미지 리빌드 문제 해결

### DIFF
--- a/lib/ui/home/view/widget/c_image_widget.dart
+++ b/lib/ui/home/view/widget/c_image_widget.dart
@@ -3,38 +3,50 @@ import 'dart:io';
 
 import 'package:flutter/material.dart';
 
-class CImageWidget extends StatelessWidget {
+class CImageWidget extends StatefulWidget {
   const CImageWidget({super.key, required this.image});
   final String image;
 
   @override
-  Widget build(BuildContext context) {
+  State<CImageWidget> createState() => _CImageWidgetState();
+}
+
+class _CImageWidgetState extends State<CImageWidget> {
+  late final Widget _cachedImage;
+
+  @override
+  void initState() {
+    super.initState();
+    _cachedImage = _buildImage(widget.image);
+  }
+
+  Widget _buildImage(String image) {
+    try {
       if (image.startsWith('data:image')) {
-      return Image.memory(
-        base64Decode(image.split(',').last),
-        width: 60,
-        height: 60,
-        fit: BoxFit.cover,
-        errorBuilder: (_, __, ___) => const Icon(Icons.broken_image),
-      );
-    } else if (image.startsWith('http')) {
-      return Image.network(
-        image,
-        width: 60,
-        height: 60,
-        fit: BoxFit.cover,
-        errorBuilder: (_, __, ___) => const Icon(Icons.broken_image),
-      );
-    } else if (image.startsWith('content://')) {
-      return Image.file(
-        File.fromUri(Uri.parse(image)),
-        width: 60,
-        height: 60,
-        fit: BoxFit.cover,
-        errorBuilder: (_, __, ___) => const Icon(Icons.broken_image),
-      );
-    } else {
-      try {
+        return Image.memory(
+          base64Decode(image.split(',').last),
+          width: 60,
+          height: 60,
+          fit: BoxFit.cover,
+          errorBuilder: (_, __, ___) => const Icon(Icons.broken_image),
+        );
+      } else if (image.startsWith('http')) {
+        return Image.network(
+          image,
+          width: 60,
+          height: 60,
+          fit: BoxFit.cover,
+          errorBuilder: (_, __, ___) => const Icon(Icons.broken_image),
+        );
+      } else if (image.startsWith('content://')) {
+        return Image.file(
+          File.fromUri(Uri.parse(image)),
+          width: 60,
+          height: 60,
+          fit: BoxFit.cover,
+          errorBuilder: (_, __, ___) => const Icon(Icons.broken_image),
+        );
+      } else {
         final file = File(Uri.parse(image).toFilePath());
         if (file.existsSync()) {
           return Image.file(
@@ -45,7 +57,6 @@ class CImageWidget extends StatelessWidget {
             errorBuilder: (_, __, ___) => const Icon(Icons.broken_image),
           );
         } else {
-          // Fallback: base64 시도
           return Image.memory(
             base64Decode(image.split(',').last),
             width: 60,
@@ -53,21 +64,15 @@ class CImageWidget extends StatelessWidget {
             fit: BoxFit.cover,
             errorBuilder: (_, __, ___) => const Icon(Icons.broken_image),
           );
-        }
-      } catch (e) {
-        // fallback 처리.
-        try {
-          return Image.memory(
-            base64Decode(image.split(',').last),
-            width: 60,
-            height: 60,
-            fit: BoxFit.cover,
-            errorBuilder: (_, __, ___) => const Icon(Icons.broken_image),
-          );
-        } catch (_) {
-          return const Icon(Icons.broken_image);
         }
       }
+    } catch (_) {
+      return const Icon(Icons.broken_image);
     }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return _cachedImage;
   }
 }

--- a/lib/ui/home/view/widget/product_list_view.dart
+++ b/lib/ui/home/view/widget/product_list_view.dart
@@ -52,6 +52,4 @@ class ProductListView extends StatelessWidget {
       },
     );
   }
-
-
 }


### PR DESCRIPTION
상품 상세 페이지에서 수량을 조절할 때마다 이미지가 깜빡이는 문제가 발생했습니다. 
이는 `CImageWidget`이 StatelessWidget으로 매번 재생성되며 내부의 이미지 위젯도 함께 rebuild되는 구조 때문입니다.

- `CImageWidget`을 `StatefulWidget`으로 변경
- `initState()`에서 최초 1회만 이미지 위젯을 생성해 `_cachedImage`에 저장
- 이후 `build()`에서는 `_cachedImage`만 반환하도록 처리하여 불필요한 이미지 재생성을 방지


